### PR TITLE
chore: bump web3modal-ts

### DIFF
--- a/projects/web3modal/package.json
+++ b/projects/web3modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mindsorg/web3modal-angular",
   "description": "Web3Modal implementation for Angular",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "homepage": "https://gitlab.com/minds/web3modal-angular",
   "repository": {
     "type": "git",
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "tslib": "^2.0.0",
-    "@mindsorg/web3modal-ts": "^1.2.2"
+    "@mindsorg/web3modal-ts": "^1.3.0"
   }
 }


### PR DESCRIPTION
In v1.3 logos are loaded using `URL(...)`
See [the commit ](https://gitlab.com/minds/web3modal-ts/-/commit/1cf71232b99dc1c8af688f179c7458a215e62087)for details